### PR TITLE
Allow parsing of feeds with invalid Content-Type

### DIFF
--- a/lib/concourse/resource/rss/feed.rb
+++ b/lib/concourse/resource/rss/feed.rb
@@ -41,7 +41,17 @@ module Concourse
           when 'application/atom+xml'
             handle_as_atom(feed)
           else
-            raise "No handler defined for #{content_type}"
+            detect_type(feed, content_type)
+          end
+        end
+
+        def detect_type(feed, content_type)
+          if feed.respond_to?(:channel)
+            handle_as_rss(feed)
+          elsif feed.respond_to?(:title)
+            handle_as_atom(feed)
+          else
+            raise "No handler defined for #{content_type}, and no valid feed content detected"
           end
         end
 

--- a/spec/fixtures/feed/dummy.xml
+++ b/spec/fixtures/feed/dummy.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<potato>
+  <this>this</this>
+  <is>is</is>
+  <not>not</not>
+  <a>a</a>
+  <feed>feed</feed>
+</potato>


### PR DESCRIPTION
Some web servers are not configured to send any of the Content-Type
headers as specified in `feed.rb`:
* 'application/rss+xml'
* 'application/rss+xml; charset=utf-8'
* 'application/atom+xml'

Although this is non-ideal, `concourse-rss-resource` should not fail
because of this: a CI run shouldn't be testing whether a third party
has correctly configured their web server.

An example of a service which returns Content-Type: text/xml is
"https://docker-hub-rss.now.sh".

The new behaviour of `handle_type` is to continue the assumption of
a valid Content-Type header, but in case none are valid, to attempt to
determine whether a feed is Atom / RSS by checking known keys that
should only exist in one or other of the specifications. If none match,
raise an error with some more context.

By the time the `handle_type` method is called, `::RSS::Parser.parse`
will have already thrown an error if the input is invalid, so no
explicit handling of this case is required here.