### PR TITLE
Allow items with missing elements

### DIFF
--- a/lib/concourse/resource/rss/feed.rb
+++ b/lib/concourse/resource/rss/feed.rb
@@ -69,11 +69,20 @@ module Concourse
 
         def cleanup(item)
           item.tap do |_cleaned|
-            item.title.chomp!
-            item.link.chomp!
+            begin
+              item.title.chomp!
+            rescue NoMethodError
+              raise "title and description missing for item" if item.description.nil?
+            end
+            item.link.chomp! unless item.link.nil?
             # item.pubDate already was a parsed Time object
-            item.description.chomp! while item.description[-1] == "\n"
-            item.guid = item.guid.content
+            raise "item is missing pubDate, so cannot be used" if item.pubDate.nil?
+            begin
+              item.description.chomp! while item.description[-1] == "\n"
+            rescue NoMethodError
+              raise "title and description missing for item" if item.title.nil?
+            end
+            item.guid = item.guid.nil? ? nil: item.guid.content
           end
         end
       end

--- a/spec/fixtures/feed/alpine.atom
+++ b/spec/fixtures/feed/alpine.atom
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:dc="http://purl.org/dc/elements/1.1/" 
+     xmlns:content="http://purl.org/rss/1.0/modules/content/" 
+     xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+     <channel>
+          <title><![CDATA[Docker Hub Images: library/alpine]]></title>
+          <description><![CDATA[A minimal Docker image based on Alpine Linux with a complete package index and only 5 MB in size!]]></description>
+          <link>https://hub.docker.com/r/library/alpine</link>
+          <generator>RSS for Node</generator>
+          <lastBuildDate>Sun, 19 Jan 2020 12:29:00 GMT</lastBuildDate>
+          <item>
+               <title><![CDATA[library/alpine:3.11.3]]></title>
+               <link>https://hub.docker.com/r/library/alpine</link>
+               <guid isPermaLink="false">83140616-1579315260881</guid>
+               <pubDate>Sat, 18 Jan 2020 02:41:00 GMT</pubDate>
+          </item>
+          <item>
+               <title><![CDATA[library/alpine:3.11]]></title>
+               <link>https://hub.docker.com/r/library/alpine</link>
+               <guid isPermaLink="false">80446357-1579315259150</guid>
+               <pubDate>Sat, 18 Jan 2020 02:40:59 GMT</pubDate>
+          </item>
+          <item>
+               <title><![CDATA[library/alpine:3]]></title>
+               <link>https://hub.docker.com/r/library/alpine</link>
+               <guid isPermaLink="false">66119067-1579315253302</guid>
+               <pubDate>Sat, 18 Jan 2020 02:40:53 GMT</pubDate>
+          </item>
+     </channel>
+</rss>

--- a/spec/fixtures/feed/alpine.atom.missing-dates
+++ b/spec/fixtures/feed/alpine.atom.missing-dates
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:dc="http://purl.org/dc/elements/1.1/" 
+     xmlns:content="http://purl.org/rss/1.0/modules/content/" 
+     xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+     <channel>
+          <title><![CDATA[Docker Hub Images: library/alpine]]></title>
+          <description><![CDATA[A minimal Docker image based on Alpine Linux with a complete package index and only 5 MB in size!]]></description>
+          <link>https://hub.docker.com/r/library/alpine</link>
+          <generator>RSS for Node</generator>
+          <lastBuildDate>Sun, 19 Jan 2020 12:29:00 GMT</lastBuildDate>
+          <item>
+               <title><![CDATA[library/alpine:3.11.3]]></title>
+               <link>https://hub.docker.com/r/library/alpine</link>
+               <guid isPermaLink="false">83140616-1579315260881</guid>
+          </item>
+          <item>
+               <title><![CDATA[library/alpine:3.11]]></title>
+               <link>https://hub.docker.com/r/library/alpine</link>
+               <guid isPermaLink="false">80446357-1579315259150</guid>
+          </item>
+          <item>
+               <title><![CDATA[library/alpine:3]]></title>
+               <link>https://hub.docker.com/r/library/alpine</link>
+               <guid isPermaLink="false">66119067-1579315253302</guid>
+          </item>
+     </channel>
+</rss>

--- a/spec/fixtures/feed/alpine.atom.missing-elements
+++ b/spec/fixtures/feed/alpine.atom.missing-elements
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:dc="http://purl.org/dc/elements/1.1/" 
+     xmlns:content="http://purl.org/rss/1.0/modules/content/" 
+     xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+     <channel>
+          <title><![CDATA[Docker Hub Images: library/alpine]]></title>
+          <description><![CDATA[A minimal Docker image based on Alpine Linux with a complete package index and only 5 MB in size!]]></description>
+          <link>https://hub.docker.com/r/library/alpine</link>
+          <generator>RSS for Node</generator>
+          <lastBuildDate>Sun, 19 Jan 2020 12:29:00 GMT</lastBuildDate>
+          <item>
+               <title><![CDATA[library/alpine:3.11.3]]></title>
+               <pubDate>Sat, 18 Jan 2020 02:41:00 GMT</pubDate>
+          </item>
+          <item>
+               <title><![CDATA[library/alpine:3.11]]></title>
+               <pubDate>Sat, 18 Jan 2020 02:40:59 GMT</pubDate>
+          </item>
+          <item>
+               <title><![CDATA[library/alpine:3]]></title>
+               <pubDate>Sat, 18 Jan 2020 02:40:53 GMT</pubDate>
+          </item>
+     </channel>
+</rss>

--- a/spec/fixtures/feed/alpine.atom.no-item-titles
+++ b/spec/fixtures/feed/alpine.atom.no-item-titles
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:dc="http://purl.org/dc/elements/1.1/" 
+     xmlns:content="http://purl.org/rss/1.0/modules/content/" 
+     xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+     <channel>
+          <title><![CDATA[Docker Hub Images: library/alpine]]></title>
+          <description><![CDATA[A minimal Docker image based on Alpine Linux with a complete package index and only 5 MB in size!]]></description>
+          <link>https://hub.docker.com/r/library/alpine</link>
+          <generator>RSS for Node</generator>
+          <lastBuildDate>Sun, 19 Jan 2020 12:29:00 GMT</lastBuildDate>
+          <item>
+               <description><![CDATA[library/alpine:3.11.3]]></description>
+               <link>https://hub.docker.com/r/library/alpine</link>
+               <guid isPermaLink="false">83140616-1579315260881</guid>
+               <pubDate>Sat, 18 Jan 2020 02:41:00 GMT</pubDate>
+          </item>
+          <item>
+               <description><![CDATA[library/alpine:3.11]]></description>
+               <link>https://hub.docker.com/r/library/alpine</link>
+               <guid isPermaLink="false">80446357-1579315259150</guid>
+               <pubDate>Sat, 18 Jan 2020 02:40:59 GMT</pubDate>
+          </item>
+          <item>
+               <description><![CDATA[library/alpine:3]]></description>
+               <link>https://hub.docker.com/r/library/alpine</link>
+               <guid isPermaLink="false">66119067-1579315253302</guid>
+               <pubDate>Sat, 18 Jan 2020 02:40:53 GMT</pubDate>
+          </item>
+     </channel>
+</rss>

--- a/spec/unit/feed_spec.rb
+++ b/spec/unit/feed_spec.rb
@@ -54,6 +54,109 @@ Concourse::Resource::RSS::Feed
     end
   end
 
+  context 'with a valid feed with no item descriptions' do
+    let(:url) { 'https://docker-hub-rss.now.sh/_/alpine.atom' }
+    let(:feed_body) { fixture('feed/alpine.atom') }
+    before do
+      stub_request(:get, url).to_return(
+        body: feed_body,
+        headers: {'Content-Type' => "text/xml"}
+      )
+    end
+
+    it 'has a first item with title' do
+      first = subject.items.first
+      expect(first.title).to eq('library/alpine:3.11.3')
+    end
+
+    it 'has a first item with an empty description' do
+      first = subject.items.first
+      expect(first.description).to be_nil
+    end
+
+    it 'has a number of items' do
+      expect(subject.items).to_not be_empty
+      expect(subject.items).to have(3).items
+    end
+  end
+
+  context 'with a valid feed with no item titles' do
+    let(:url) { 'https://docker-hub-rss.now.sh/_/alpine.atom' }
+    let(:feed_body) { fixture('feed/alpine.atom.no-item-titles') }
+    before do
+      stub_request(:get, url).to_return(
+        body: feed_body,
+        headers: {'Content-Type' => "text/xml"}
+      )
+    end
+
+    it 'has a first item with an empty title' do
+      first = subject.items.first
+      expect(first.title).to be_nil
+    end
+    
+    it 'has a first item with description' do
+      first = subject.items.first
+      expect(first.description).to eq('library/alpine:3.11.3')
+    end
+
+    it 'has a number of items' do
+      expect(subject.items).to_not be_empty
+      expect(subject.items).to have(3).items
+    end
+  end
+
+  context 'with a valid feed with missing elements' do
+    let(:url) { 'https://docker-hub-rss.now.sh/_/alpine.atom' }
+    let(:feed_body) { fixture('feed/alpine.atom.missing-elements') }
+    before do
+      stub_request(:get, url).to_return(
+        body: feed_body,
+        headers: {'Content-Type' => "text/xml"}
+      )
+    end
+  
+    it 'has a first item with title' do
+      first = subject.items.first
+      expect(first.title).to eq('library/alpine:3.11.3')
+    end
+
+    it 'has a first item an empty link' do
+      first = subject.items.first
+      expect(first.link).to be_nil
+    end
+    
+    it 'has a first item with an empty description' do
+      first = subject.items.first
+      expect(first.description).to be_nil
+    end
+
+    it 'has a first item with an empty guid' do
+      first = subject.items.first
+      expect(first.guid).to be_nil
+    end
+
+    it 'has a number of items' do
+      expect(subject.items).to_not be_empty
+      expect(subject.items).to have(3).items
+    end
+  end
+
+  context 'with a valid feed with missing dates' do
+    let(:url) { 'https://docker-hub-rss.now.sh/_/alpine.atom' }
+    let(:feed_body) { fixture('feed/alpine.atom.missing-dates') }
+    before do
+      stub_request(:get, url).to_return(
+        body: feed_body,
+        headers: {'Content-Type' => "text/xml"}
+      )
+    end
+  
+    it 'complains if the date is empty' do
+      expect { subject } .to raise_error(RuntimeError)
+    end
+  end
+
   context 'with an empty feed' do
     let(:feed_body) { '' }
 


### PR DESCRIPTION
The RSS Specification[1] states that "All elements of an item are
optional, however at least one of title or description must be present".
It is therefore incorrect to error if any of the items' elements are
omitted.

Concourse, however, requires something unique to identify the specific
resource version by, so pubDate is not allowed to not be set. This
should be work-around-able, but the specific case I'm fixing does not
require this.

[1]https://validator.w3.org/feed/docs/rss2.html#hrelementsOfLtitemgt