### PR TITLE
Last build date is not always last item date

### DIFF
--- a/lib/concourse/resource/rss/check.rb
+++ b/lib/concourse/resource/rss/check.rb
@@ -36,8 +36,7 @@ module Concourse
 
         def first
           return [] if @feed.items.empty?
-
-          [{ 'pubDate' => @feed.last_build_date }]
+          [{ 'pubDate' => @feed.last_item_date }]
         end
       end
     end

--- a/lib/concourse/resource/rss/feed.rb
+++ b/lib/concourse/resource/rss/feed.rb
@@ -8,7 +8,7 @@ module Concourse
   module Resource
     module RSS
       class Feed
-        attr_reader :title, :items, :last_build_date
+        attr_reader :title, :items, :last_build_date, :last_item_date
 
         def initialize(url)
           response = Faraday.get(url)
@@ -59,12 +59,14 @@ module Concourse
           @title = feed.channel.title.chomp
           @last_build_date = feed.channel.lastBuildDate
           @items = feed.items.map { |item| cleanup(item) }
+          @last_item_date = @items.first.nil? ? nil : @items.first.pubDate
         end
 
         def handle_as_atom(feed)
           @title = feed.title.content
           @last_build_date = feed.updated.content
           @items = feed.items # .map { |item| cleanup(item) }
+          @last_item_date = @items.first.nil? ? nil : @items.first.updated.content
         end
 
         def cleanup(item)

--- a/spec/fixtures/feed/postgres-versions.rss
+++ b/spec/fixtures/feed/postgres-versions.rss
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0"><channel><title>PostgreSQL latest versions</title><link>https://www.postgresql.org/</link><description>PostgreSQL latest versions</description><atom:link href="https://www.postgresql.org/versions.rss" rel="self"></atom:link><language>en-us</language><lastBuildDate>Thu, 27 Oct 2016 00:00:00 +0000</lastBuildDate>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0"><channel><title>PostgreSQL latest versions</title><link>https://www.postgresql.org/</link><description>PostgreSQL latest versions</description><atom:link href="https://www.postgresql.org/versions.rss" rel="self"></atom:link><language>en-us</language><lastBuildDate>Thu, 28 Oct 2016 00:00:00 +0000</lastBuildDate>
 <item><title>9.6.1
 </title><link>https://www.postgresql.org/docs/9.6/static/release-9-6-1.html</link><description>9.6.1 is the latest release in the 9.6 series.
 

--- a/spec/unit/check_spec.rb
+++ b/spec/unit/check_spec.rb
@@ -137,7 +137,7 @@ describe Concourse::Resource::RSS::Check do
     let(:source) { { 'url' => 'https://github.com/hashicorp/vagrant/releases.atom' } }
     let(:version) { nil }
 
-    it 'responds with an non-empty list' do
+    it 'responds with a non-empty list' do
       output = subject.call(source, version)
       expect(output).to_not be_empty
     end

--- a/spec/unit/feed_spec.rb
+++ b/spec/unit/feed_spec.rb
@@ -20,7 +20,11 @@ Concourse::Resource::RSS::Feed
     end
 
     it 'has the last build date' do
-      expect(subject.last_build_date).to eq(Time.parse('Thu, 27 Oct 2016 00:00:00 +0000'))
+      expect(subject.last_build_date).to eq(Time.parse('Thu, 28 Oct 2016 00:00:00 +0000'))
+    end
+
+    it 'has the last item date' do
+      expect(subject.last_item_date).to eq(Time.parse('Thu, 27 Oct 2016 00:00:00 +0000'))
     end
 
     it 'has a number of items' do


### PR DESCRIPTION
Usually, RSS feeds are static and the date the file was last built is
the same as the publishing / update date of the most recent item,
however this is not always the case - sometimes feeds are generated
dynamically, and the build date of the file is set to `Time.now`.

In the case of a new resource being created, the pubDate is initially
set to the pubDate of the latest item.